### PR TITLE
Persist `cargo-compete` credential files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,13 +8,13 @@
 	},
 
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
+	"mounts": [
+		{
+			"source": "devcontainer-atcoder-rust-${devcontainerId}-xdg-data-home",
+			"target": "/mnt/xdg-data-home",
+			"type": "volume"
+		}
+	],
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
@@ -31,7 +31,7 @@
 	"postCreateCommand": [
 		"sh",
 		"-c",
-		"cd \"$(rustc --print sysroot)/lib/rustlib/src/rust\" && ln -s ./src ./library"
+		"cd \"$(rustc --print sysroot)/lib/rustlib/src/rust\" && ln -s ./src ./library && sudo chown ${USER}: -R /mnt/xdg-data-home"
 	],
 	"postStartCommand": "rustup show",
 
@@ -42,6 +42,7 @@
 	// "remoteUser": "root"
 
 	"containerEnv": {
+		"XDG_DATA_HOME": "/mnt/xdg-data-home",
 		"CARGO_BUILD_TARGET_DIR": "/tmp/rust-target"
 	}
 }

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ $ atcoder test
 # Submit your code
 $ atcoder submit
 ```
+
+[The cookies and tokens for cargo-compete](https://github.com/qryxip/cargo-compete/blob/master/README.md#cookies-and-tokens) are stored under `/mnt/xdg-data-home` in container. since it is Docker named volume, so it is not volatile even if the Dev Container is rebuilt.


### PR DESCRIPTION
Save credential files to Docker named volume. 