### PR TITLE
Place `.gitkeep` under testcases at `atcoder new`

### DIFF
--- a/bin/atcoder
+++ b/bin/atcoder
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 
+set -eu
+
+__ATCODER_WORKSPACE_DIR="$(cd $(dirname $0) && cd ../ && pwd)"
+
 #
 # Store `cargo-compete` credentials under your workspace folder
 #   ref: https://github.com/qryxip/cargo-compete#cookies-and-tokens
 #
-export XDG_DATA_HOME="$(cd $(dirname $0) && cd ../ && pwd)/.local/share"
+export XDG_DATA_HOME="$__ATCODER_WORKSPACE_DIR/.local/share"
 
 CARGO_COMPETE_SUBCOMMAND="$1"
 case "$CARGO_COMPETE_SUBCOMMAND" in
     'init' | 'login' | 'participate')
         shift
         cargo compete "$CARGO_COMPETE_SUBCOMMAND" atcoder "$@"
+        ;;
+    'new')
+        cargo compete "$@"
+
+        #
+        # Workaround: Manage under `testcases` with `git`
+        #   ref: https://github.com/qryxip/cargo-compete/pull/198
+        #
+        find "$__ATCODER_WORKSPACE_DIR"/*/testcases -type d -empty -exec touch {}/.gitkeep \;
         ;;
     *)
         cargo compete "$@"


### PR DESCRIPTION
This PR is a workaround for https://github.com/qryxip/cargo-compete/pull/198