### PR TITLE
Fix `cargo-compete` build error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.70-bookworm
-RUN cargo install cargo-compete
+RUN cargo install --locked cargo-compete
 
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 COPY --from=0 /usr/local/cargo/bin/cargo-compete /usr/local/bin/


### PR DESCRIPTION
Add `--locked` option to `cargo install`