### PR TITLE
Fix `--keep-going` warnings by rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,20 @@
 {
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--workspace",
+        "--message-format=json-diagnostic-rendered-ansi",
+        "--all-targets"
+    ],
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--workspace",
+        "--message-format=json-diagnostic-rendered-ansi",
+        "--all-targets"
+    ],
     "terminal.integrated.env.linux": {
         "PATH": "${workspaceFolder}/bin:${env:PATH}"
     },


### PR DESCRIPTION
Do not pass `--keep-going` flag to `cargo` command.