### PR TITLE
Pin version of `rust-analyzer` extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,7 @@
 	"customizations": {
 		"vscode": {
 				"extensions": [
-						"rust-lang.rust-analyzer",
+						"rust-lang.rust-analyzer@0.3.2319",
 						"tamasfe.even-better-toml",
 						"vadimcn.vscode-lldb"
 				]


### PR DESCRIPTION
In `v0.3.2328` or newest extensions, dropped support for Rust toolchains older than 1.82.

https://github.com/rust-lang/rust-analyzer/releases/tag/2025-03-03